### PR TITLE
Add `--since` flag to control the range of PRs to display

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,9 @@ module github.com/corneliusweig/release-notes
 go 1.12
 
 require (
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/google/go-github/v28 v28.1.1
+	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
+github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
+github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
@@ -22,6 +24,8 @@ github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czP
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=

--- a/listpullreqs.go
+++ b/listpullreqs.go
@@ -91,7 +91,7 @@ var rootCmd = &cobra.Command{
 
 func main() {
 	rootCmd.Flags().StringVar(&token, "token", "", "Specify personal Github Token if you are hitting a rate limit anonymously. https://github.com/settings/tokens")
-	rootCmd.Flags().StringVar(&since, "since", "any", "The previous tag up to which PRs should be collected (one of any, patch, minor, major, or a valid semver) [defaults to 'any']")
+	rootCmd.Flags().StringVar(&since, "since", "patch", "The previous tag up to which PRs should be collected (one of any, patch, minor, major, or a valid semver) [defaults to 'patch']")
 	if err := rootCmd.Execute(); err != nil {
 		logrus.Fatal(err)
 	}

--- a/listpullreqs.go
+++ b/listpullreqs.go
@@ -44,18 +44,32 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"regexp"
 	"syscall"
 
+	"github.com/blang/semver"
 	"github.com/google/go-github/v28/github"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"golang.org/x/oauth2"
 )
 
+const (
+	sinceAny   = "any"
+	sincePatch = "patch"
+	sinceMinor = "minor"
+	sinceMajor = "major"
+)
+
 var (
-	token string
 	org   string
 	repo  string
+	token string
+	since string
+
+	// versionMatchRE matches the raw version number from a string
+	versionMatchRE = regexp.MustCompile(`^\s*v?(.*)$`)
 )
 
 const longDescription = `The script uses the GitHub API to retrieve a list of all merged pull
@@ -77,6 +91,7 @@ var rootCmd = &cobra.Command{
 
 func main() {
 	rootCmd.Flags().StringVar(&token, "token", "", "Specify personal Github Token if you are hitting a rate limit anonymously. https://github.com/settings/tokens")
+	rootCmd.Flags().StringVar(&since, "since", "any", "The previous tag up to which PRs should be collected (one of any, patch, minor, major, or a valid semver) [defaults to 'any']")
 	if err := rootCmd.Execute(); err != nil {
 		logrus.Fatal(err)
 	}
@@ -86,16 +101,12 @@ func printPullRequests() {
 	ctx := contextWithCtrlCHandler()
 	client := getClient(ctx)
 
-	releases, _, err := client.Repositories.ListReleases(ctx, org, repo, &github.ListOptions{})
+	lastRelease, err := fetchLastRelease(ctx, client)
 	if err != nil {
-		logrus.Fatalf("Failed to list releases: %v", err)
+		logrus.Fatal(err)
 	}
-	if len(releases) == 0 {
-		logrus.Warningf("Could not find any releases for %s/%s", org, repo)
-		return
-	}
-	lastReleaseTime := releases[0].GetPublishedAt()
-	fmt.Printf("Collecting pull request that were merged since the last release: %s (%s)\n", releases[0].GetTagName(), lastReleaseTime)
+	lastReleaseTime := lastRelease.GetPublishedAt().Time
+	fmt.Fprintf(os.Stderr, "Collecting pull request that were merged since the last release: %s (%s)\n", lastRelease.GetTagName(), lastReleaseTime)
 
 	for page := 1; page != 0; {
 		pullRequests, resp, err := client.PullRequests.List(ctx, org, repo, &github.PullRequestListOptions{
@@ -114,15 +125,67 @@ func printPullRequests() {
 
 		for idx := range pullRequests {
 			pr := pullRequests[idx]
-			if pr.GetUpdatedAt().Before(lastReleaseTime.Time) {
+			if pr.GetUpdatedAt().Before(lastReleaseTime) {
 				page = 0 // we are done now
 				break
 			}
-			if pr.MergedAt != nil && pr.MergedAt.After(lastReleaseTime.Time) {
+			if pr.MergedAt != nil && pr.MergedAt.After(lastReleaseTime) {
 				fmt.Printf("* %s [#%d](https://github.com/%s/%s/pull/%d)\n", pr.GetTitle(), pr.GetNumber(), org, repo, pr.GetNumber())
 			}
 		}
 	}
+}
+
+func fetchLastRelease(ctx context.Context, client *github.Client) (*github.RepositoryRelease, error) {
+	releases, _, err := client.Repositories.ListReleases(ctx, org, repo, &github.ListOptions{})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to list releases")
+	}
+	matches, err := toVersionMatcher(since)
+	if err != nil {
+		return nil, err
+	}
+	for _, release := range releases {
+		version, err := parseSemver(release.GetTagName())
+		if err != nil {
+			return nil, err
+		}
+		if matches(version) {
+			return release, nil
+		}
+	}
+	return nil, fmt.Errorf("no previous release found tag %s/%s", org, repo)
+}
+
+func toVersionMatcher(since string) (func(semver.Version) bool, error) {
+	// magic version specifiers
+	switch since {
+	case sinceAny:
+		return func(_ semver.Version) bool { return true }, nil
+	case sincePatch:
+		return func(v semver.Version) bool { return len(v.Pre) == 0 }, nil
+	case sinceMinor:
+		return func(v semver.Version) bool { return v.Patch == 0 && len(v.Pre) == 0 }, nil
+	case sinceMajor:
+		return func(v semver.Version) bool { return v.Minor == 0 && v.Patch == 0 && len(v.Pre) == 0 }, nil
+	}
+
+	previousVersion, err := parseSemver(since)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not parse semver %q", since)
+	}
+
+	return previousVersion.GTE, nil
+}
+
+func parseSemver(tagName string) (semver.Version, error) {
+	parts := versionMatchRE.FindStringSubmatch(tagName)
+	if parts == nil {
+		return semver.Version{}, fmt.Errorf("%q does not look like a version string", tagName)
+	}
+
+	version, err := semver.Parse(parts[1])
+	return version, errors.Wrapf(err, "could not parse as semver")
 }
 
 func getClient(ctx context.Context) *github.Client {

--- a/listpullreqs_test.go
+++ b/listpullreqs_test.go
@@ -1,0 +1,59 @@
+package main
+
+import "testing"
+
+func Test_isPrereleaseSemver(t *testing.T) {
+	tests := []struct {
+		name      string
+		tag       string
+		expected  bool
+		shouldErr bool
+	}{
+		{
+			name:     "simple semver",
+			tag:      "  v1.0.0",
+			expected: false,
+		},
+		{
+			name:     "simple semver with pre",
+			tag:      "v1.0.0-alpha.1",
+			expected: true,
+		},
+		{
+			name:     "simple semver with pre and build",
+			tag:      "v1.0.0-alpha.1+12342",
+			expected: true,
+		},
+		{
+			name:     "simple semver with build",
+			tag:      "v1.0.0+12342",
+			expected: false,
+		},
+		{
+			name:      "not a semver",
+			tag:       "v1.x.0+12342",
+			shouldErr: true,
+		},
+		{
+			name:      "not a semver at all",
+			tag:       "v a b d1.x.0+12342",
+			shouldErr: true,
+		},
+		{
+			name:      "empty input",
+			tag:       "",
+			shouldErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := parseSemver(test.tag)
+			if err == nil && test.shouldErr {
+				t.Errorf("Expected %q to fail", test.tag)
+			} else if err != nil && !test.shouldErr {
+				t.Errorf("Expected %q not to fail", test.tag)
+			}
+		})
+	}
+}


### PR DESCRIPTION
There is now a hard constraint that queried repositories must use semver.
The `--since` flag controls which of the previous releases to take as lower boundary (excluding) for PRs.
It understands semver or the following magic strings:

 - `any`: selects the _last_ release, for example v2.1.3-alpha
 - `patch`: selects the last stable release, for example v2.1.3
 - `minor`: selects the last minor release, for example v2.1.0
 - `major`: selects the last major release, for example v2.0.0

The flag defaults to `patch` so that alpha releases are ignored when searching for the previous release.